### PR TITLE
Use alternate image as fallback for creation date

### DIFF
--- a/main.py
+++ b/main.py
@@ -268,7 +268,8 @@ async def _set_creation_date(session: aiohttp.ClientSession, image: dict) -> Non
             data = await response.json()
             images = data['value']
             decoded_image_id = unquote(image_id)
-            resp_image = [img for img in images if img['imageId'] == decoded_image_id][0]
+            resp_image_arr = [img for img in images if img['imageId'] == decoded_image_id]
+            resp_image = images[0] if len(resp_image_arr) < 1 else resp_image_arr[0]
             creation_date_string = resp_image['datePublished']
             creation_date_object = dateutil_parser.parse(creation_date_string).astimezone(timezone.utc)
             creation_date_string_formatted = creation_date_object.strftime('%Y-%m-%dT%H%MZ')


### PR DESCRIPTION
This happens when the saved image is valid, but not present among the generated images in the prompt URL.

This behavior is also present when accessing the saved image manually in the collection via the browser. ie. The thumbnail shows the correct image, but is not among the images in the prompt URL.

From initial testing, the creation date and prompt of the alternate image, which is the first of the generated images in the prompt URL, seems to line up with the saved one.

In other words, this handles cases Image X is accessed with the correct and valid thumbnail and image URL, but prompt URL contains images A,(B),(C),(D) with matching prompt and date.