### PR TITLE
Update aiohttp to 3.9.0 to be compatible with Python 3.12

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 aiofiles~=23.2.1
-aiohttp~=3.8.6
+aiohttp~=3.9.0
 aiohttp_retry~=2.8.3
 piexif~=1.1.3
 Pillow~=10.1.0


### PR DESCRIPTION
Update aiohttp to 3.9.0 so it's compatible with latest Python 3.12. Otherwise it can't build wheels.
See https://github.com/aio-libs/aiohttp/issues/7739#issuecomment-1773868351