### PR TITLE
feat: use local time zone for file naming

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,5 @@
 [filename]
+
 # You can define your own custom pattern to be used for naming the image files.
 # Available parameters are:
 # date: The time the image was created using the Bing Image Creator. The date uses ISO-8601 formatting.
@@ -8,8 +9,11 @@
 #
 # The default file name would look like this: "2023-11-11T1512Z_0133_a-cute-cat".
 filename_pattern = "$date$sep$index$sep$prompt"
+# Uses your local time zone to format the filename. Set to false to use UTC.
+use_local_time_zone = true
 
 [collection]
+
 # You can define if you want to only download specific collections or from all collections.
 # Leave the array empty to download all entries.
 # Also use "Saved Images" for the default collection and not your localization.

--- a/main.py
+++ b/main.py
@@ -52,7 +52,8 @@ class BingCreatorImageDownload:
         await self.__set_creation_dates()
         await self.__download_and_zip_images()
 
-    def __gather_image_data(self) -> list:
+    @staticmethod
+    def __gather_image_data() -> list:
         """
         Gathers all necessary data for each image from all collections.
         :return: A list containing dictionaries containing the interesting data for each image.
@@ -143,8 +144,14 @@ class BingCreatorImageDownload:
                     logging.info(f"Downloading image from: {image_dict['image_link']}")
                     if response.status == 200:
                         filename_image_prompt = await BingCreatorImageUtility.slugify(image_dict['image_prompt'])
+                        if config['filename']['use_local_time_zone']:
+                            creation_date = dateutil_parser.parse(image_dict['creation_date']) \
+                                .astimezone() \
+                                .strftime('%Y-%m-%dT%H%M%z')
+                        else:
+                            creation_date = image_dict['creation_date']
                         file_name_substitute_dict = {
-                            'date': image_dict['creation_date'],
+                            'date': creation_date,
                             'index': image_dict['index'],
                             'prompt': filename_image_prompt[:50],
                             'sep': '_'
@@ -169,8 +176,14 @@ class BingCreatorImageDownload:
                                 filename_image_prompt = await BingCreatorImageUtility.slugify(
                                     image_dict['image_prompt']
                                 )
+                                if config['filename']['use_local_time_zone']:
+                                    creation_date = dateutil_parser.parse(image_dict['creation_date']) \
+                                        .astimezone() \
+                                        .strftime('%Y-%m-%dT%H%M%z')
+                                else:
+                                    creation_date = image_dict['creation_date']
                                 file_name_substitute_dict = {
-                                    'date': image_dict['creation_date'],
+                                    'date': creation_date,
                                     'index': image_dict['index'],
                                     'prompt': filename_image_prompt[:50],
                                     'sep': '_'


### PR DESCRIPTION
Resolves #18.  
Uses the time zone of the user by default for file naming.  
UTC can be used instead by setting the `use_local_time_zone` property to `false`.