### PR TITLE
feat: use all available URLs as fallbacks

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -8,6 +8,7 @@
 # sep: A seperator that may be used between parameters.
 #
 # The default file name would look like this: "2023-11-11T1512Z_0133_a-cute-cat".
+# If the width is smaller than 1024 pixels, a "_T" for thumbnail will be added.
 filename_pattern = "$date$sep$index$sep$prompt"
 # Uses your local time zone to format the filename. Set to false to use UTC.
 use_local_time_zone = true


### PR DESCRIPTION
This PR resolves the first part of #17.  
The URLs are tried in the specified order and the URL that was used to download the image is written to the EXIF Metadata.  
The thumbnail url references are mostly removed, as they are often full sized too.  
If an image is not full sized however, a `_T` is appended to the filename. 
Full sized in this case means height or width being below 1024 pixels.  
As the images are just squared in the current implementation, only the width is checked.