### PR TITLE
feat: add statistics for image downloads

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -24,6 +24,11 @@ collections_to_include = []
 
 [debug]
 
+# Enables additional debug statements and debug functionality.
 debug = true
+# Enables logging the console output to a file.
 use_log_file = true
+# The filename of the log file.
 debug_filename = "bing_image_creator.log"
+# Displays more detailed statistics at the end of the program.
+detailed_statistics = false

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 aiofiles~=23.2.1
-aiohttp~=3.9.0
+aiohttp~=3.9.1
 aiohttp_retry~=2.8.3
 piexif~=1.1.3
 Pillow~=10.1.0
@@ -7,3 +7,4 @@ python-dateutil~=2.8.2
 python-dotenv~=1.0.0
 requests~=2.31.0
 urllib3~=2.0.7
+tabulate~=0.9.0


### PR DESCRIPTION
This PR resolves #26 
By default only a simple stat like `x out of y images were downloaded successfully` is displayed.  
The detailed statistics are outputted in the terminal and a markdown file named `detailed_statistics.md` in markdown format if the toggle `detailed_statistics` in the `config.toml` is set to `true`.  
Each row contains the custom unique index, prompt, page url, success status, reason, number of attempts and whether it is a thumbnail.  
Most images are tried a maximum of 3 times instead of 4, because often the `contentUrl` and `thumbnailUrl` from the detail API are the same and only one is added leading to a maximum of 3 unique URLs to try.  
