### PR TITLE
fix: rename pillow import

### DIFF
--- a/models/collection_import.py
+++ b/models/collection_import.py
@@ -9,7 +9,7 @@ from asyncio import Semaphore
 
 import aiohttp
 import requests
-from PIL import Image
+from PIL import Image as PIL_Image
 
 from utilities.image_validator import ImageValidator
 from utilities.network_utility import NetworkUtility
@@ -133,7 +133,7 @@ class CollectionImport:
         async with aiohttp.ClientSession() as session:
             async with NetworkUtility.create_retry_client(session).get(thumbnail_url) as response:
                 thumbnail_content = await response.read()
-                img = Image.open(io.BytesIO(thumbnail_content))
+                img = PIL_Image.open(io.BytesIO(thumbnail_content))
                 img.thumbnail((468, 468))
                 buffered = io.BytesIO()
                 img.save(buffered, format="JPEG")

--- a/models/image_download.py
+++ b/models/image_download.py
@@ -7,7 +7,7 @@ from typing import List
 
 import aiofiles.tempfile
 import aiohttp
-from PIL import Image
+from PIL import Image as PIL_Image
 import string
 from dateutil import parser as dateutil_parser
 
@@ -105,7 +105,7 @@ class ImageDownload:
                             template = string.Template(self.__config['filename']['filename_pattern'])
                             file_name_formatted = template.safe_substitute(file_name_substitute_dict)
                             image_bytes = await response.read()
-                            with Image.open(BytesIO(image_bytes)) as pil_image:
+                            with PIL_Image.open(BytesIO(image_bytes)) as pil_image:
                                 image_width = pil_image.width
                             if image_width < 1024:
                                 file_name_formatted += '_T'


### PR DESCRIPTION
This PR will resolve #31.
I have renamed the pillow import to differentiate the Image dataclass.