### PR TITLE
fix: increase timeout for detail API

### DIFF
--- a/utilities/network_utility.py
+++ b/utilities/network_utility.py
@@ -33,7 +33,7 @@ class NetworkUtility:
         :return: The created retry client.
         """
         statuses = {x for x in range(100, 600) if x != 200}
-        retry_options = ExponentialRetry(statuses=statuses)
+        retry_options = ExponentialRetry(attempts=8, start_timeout=1, max_timeout=128, statuses=statuses)
         retry_client = RetryClient(client_session=session, retry_options=retry_options)
 
         return retry_client


### PR DESCRIPTION
Resolves #34.
The attempts are increased to 8 and the max timeout to 128 seconds.
Timeout is calculated as 2 ** attempt.
This should prevent receiving a 203 from the details API in the last request.