### PR TITLE
Reverse the file image list before downloading

### DIFF
--- a/strategies/file_image_source_strategy.py
+++ b/strategies/file_image_source_strategy.py
@@ -19,6 +19,7 @@ class FileImageSourceStrategy(ImageSourceStrategy):
     async def get_images(self) -> List[Image]:
         logging.info(f"Fetching metadata of images...")
         image_id_list = await FileImageSourceStrategy.__get_image_ids_from_file()
+        image_id_list = reversed(image_id_list)
         semaphore = Semaphore(250)
         tasks = [
             FileImageSourceStrategy.get_image_data(image_ids, semaphore, index)

--- a/strategies/file_image_source_strategy.py
+++ b/strategies/file_image_source_strategy.py
@@ -19,7 +19,6 @@ class FileImageSourceStrategy(ImageSourceStrategy):
     async def get_images(self) -> List[Image]:
         logging.info(f"Fetching metadata of images...")
         image_id_list = await FileImageSourceStrategy.__get_image_ids_from_file()
-        image_id_list = reversed(image_id_list)
         semaphore = Semaphore(250)
         tasks = [
             FileImageSourceStrategy.get_image_data(image_ids, semaphore, index)
@@ -69,6 +68,6 @@ class FileImageSourceStrategy(ImageSourceStrategy):
         with open("images_clipboard.txt", "r", encoding='utf8') as f:
             content = f.read().splitlines()
         image_url_list = [line for line in content if line.startswith("https://www.bing.com/images/create")]
-        image_ids = [await ImageUtility.extract_set_and_image_id(url) for url in image_url_list]
+        image_ids = [await ImageUtility.extract_set_and_image_id(url) for url in reversed(image_url_list)]
 
         return image_ids


### PR DESCRIPTION
Currently, the indices are reversed when compared with the API method.

Ideally, as with the API method, the first image should be the one at the bottom right of the collection, which usually corresponds to the oldest item.

But because of how the clipboard is normally copied with the "Select all results in this collection" button, the first image ends up being the topmost entry in the clipboard, corresponding to the top left item in the collection, which is incorrect.

This commit would fix the issue and preserve naming parity with the API method.