### PR TITLE
Add retries for obtaining image data

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -29,6 +29,10 @@ collections_to_include = []
 # - file: Uses the images_clipboard.txt file to gather image data. Does not contain same thumbnail data as Collection API.
 method = "file"
 
+[detail_api]
+# Because the detail API does not always return valid values, it's retried the specified amount of times.
+max_attempts = 5
+
 [debug]
 
 # Enables additional debug statements and debug functionality.

--- a/strategies/file_image_source_strategy.py
+++ b/strategies/file_image_source_strategy.py
@@ -6,6 +6,7 @@ from typing import List, Dict
 
 from dateutil import parser as dateutil_parser
 
+from utilities.config import Config
 from models.image import Image
 from strategies.image_source_strategy import ImageSourceStrategy
 from utilities.image_utility import ImageUtility
@@ -20,7 +21,7 @@ class FileImageSourceStrategy(ImageSourceStrategy):
         logging.info(f"Fetching metadata of images...")
         image_id_list = await FileImageSourceStrategy.__get_image_ids_from_file()
         semaphore = Semaphore(250)
-        images = await self.get_image_data_retry(image_id_list, semaphore, 5)
+        images = await self.get_image_data_retry(image_id_list, semaphore, Config().detail_max_attempts())
         images = [image for image in images if image is not None]
 
         return images

--- a/utilities/config.py
+++ b/utilities/config.py
@@ -14,3 +14,10 @@ class Config:
     @property
     def value(self):
         return self._config
+
+    def detail_max_attempts(self) -> int:
+        """
+        Returns the maximum number of attempts to get detailed information for an image.
+        :return: The value specified in the config file.
+        """
+        return self._config['detail_api']['max_attempts']

--- a/utilities/image_utility.py
+++ b/utilities/image_utility.py
@@ -84,8 +84,6 @@ class ImageUtility:
         async with semaphore:
             async with aiohttp.ClientSession() as session:
                 retry_client = NetworkUtility.create_retry_client(session, attempts=8, max_timeout=128)
-                retry_client.retry_options.evaluate_response_callback = \
-                    NetworkUtility.should_retry_get_detail_image
                 async with retry_client.get(request_url) as response:
                     if response.status == 200:
                         data = await response.json()

--- a/utilities/image_utility.py
+++ b/utilities/image_utility.py
@@ -84,6 +84,8 @@ class ImageUtility:
         async with semaphore:
             async with aiohttp.ClientSession() as session:
                 retry_client = NetworkUtility.create_retry_client(session, attempts=8, max_timeout=128)
+                retry_client.retry_options.evaluate_response_callback = \
+                    NetworkUtility.should_retry_get_detail_image
                 async with retry_client.get(request_url) as response:
                     if response.status == 200:
                         data = await response.json()

--- a/utilities/image_utility.py
+++ b/utilities/image_utility.py
@@ -83,7 +83,8 @@ class ImageUtility:
 
         async with semaphore:
             async with aiohttp.ClientSession() as session:
-                async with NetworkUtility.create_retry_client(session).get(request_url) as response:
+                retry_client = NetworkUtility.create_retry_client(session, attempts=8, max_timeout=128)
+                async with retry_client.get(request_url) as response:
                     if response.status == 200:
                         data = await response.json()
                         if 'value' in data and data['value'] is not None:

--- a/utilities/network_utility.py
+++ b/utilities/network_utility.py
@@ -54,3 +54,18 @@ class NetworkUtility:
         if invalid_response:
             pass
         return invalid_response
+
+    @staticmethod
+    async def should_retry_get_detail_image(response: aiohttp.ClientResponse) -> bool:
+        """
+        Callback functions for the detail API for retrying.
+        :param response: The response to evaluate.
+        :return: Whether the request should be retried or not.
+        """
+        should_retry = True
+        if response.status == 200:
+            data = await response.json()
+            valid_response = data is not None and 'value' in data and data['value'] is not None
+            should_retry = not valid_response
+
+        return should_retry

--- a/utilities/network_utility.py
+++ b/utilities/network_utility.py
@@ -26,7 +26,7 @@ class NetworkUtility:
         return session
 
     @staticmethod
-    def create_retry_client(session: aiohttp.ClientSession, attempts=3, max_timeout=8) -> aiohttp_retry.RetryClient:
+    def create_retry_client(session: aiohttp.ClientSession, attempts=4, max_timeout=16) -> aiohttp_retry.RetryClient:
         """
         Creates a retry client used for making requests to the different APIs.
         :param session: Session to use in the retry client.

--- a/utilities/network_utility.py
+++ b/utilities/network_utility.py
@@ -26,14 +26,16 @@ class NetworkUtility:
         return session
 
     @staticmethod
-    def create_retry_client(session: aiohttp.ClientSession) -> aiohttp_retry.RetryClient:
+    def create_retry_client(session: aiohttp.ClientSession, attempts=3, max_timeout=8) -> aiohttp_retry.RetryClient:
         """
         Creates a retry client used for making requests to the different APIs.
         :param session: Session to use in the retry client.
+        :param attempts: How many times a request should be retried.
+        :param max_timeout: Maximum timeout in seconds.
         :return: The created retry client.
         """
         statuses = {x for x in range(100, 600) if x != 200}
-        retry_options = ExponentialRetry(attempts=8, start_timeout=1, max_timeout=128, statuses=statuses)
+        retry_options = ExponentialRetry(attempts=attempts, start_timeout=1, max_timeout=max_timeout, statuses=statuses)
         retry_client = RetryClient(client_session=session, retry_options=retry_options)
 
         return retry_client

--- a/utilities/network_utility.py
+++ b/utilities/network_utility.py
@@ -54,18 +54,3 @@ class NetworkUtility:
         if invalid_response:
             pass
         return invalid_response
-
-    @staticmethod
-    async def should_retry_get_detail_image(response: aiohttp.ClientResponse) -> bool:
-        """
-        Callback functions for the detail API for retrying.
-        :param response: The response to evaluate.
-        :return: Whether the request should be retried or not.
-        """
-        should_retry = True
-        if response.status == 200:
-            data = await response.json()
-            valid_response = data is not None and 'value' in data and data['value'] is not None
-            should_retry = not valid_response
-
-        return should_retry


### PR DESCRIPTION
Clarifying #34, it was happening to `200` responses. Referring to an excerpt of the logs:
```
2024-01-13 18:32:07,483 INFO Fetching metadata of images...
2024-01-13 18:32:09,041 ERROR Failed to get detailed information for image: {'image_set_id': '...885c', 'image_id': 'ExYd...'} for Reason: API response is missing data.
```
It was in the form `Failed to get detailed information for image: {image_ids} for Reason: API response is missing data.`, which corresponds to the logging from `get_image_data()`. Had the response not been `200`, it should have logged from `get_detail_image()` from `image_utility.py`, which wasn't the case (notice the missing second `:` after `Reason:`).

As of the latest commit, I was still getting the same errors, with the error even being logged just under 2 seconds apart:
```
2024-01-14 00:50:34,012 INFO Fetching metadata of images...
2024-01-14 00:50:35,614 ERROR Failed to get detailed information for image: {'image_set_id': '...2bd6', 'image_id': 'CQp9...'} for Reason: API response is missing data.
```

With this PR, the program would be able to retry and retrieve the image data from the links several times until data is successfully retrieved for all images, merging results from previous attempt until no `None` values remain.

For now, the retries is set to 5, which should ideally be configurable as discussed in #34 in a future commit. As it is, I was able to download all 157 images successfully with the file method and this PR within 2-3 tries.