### PR TITLE
fix: add evaluation callback to detail API requests

### DIFF
--- a/utilities/image_utility.py
+++ b/utilities/image_utility.py
@@ -84,6 +84,8 @@ class ImageUtility:
         async with semaphore:
             async with aiohttp.ClientSession() as session:
                 retry_client = NetworkUtility.create_retry_client(session, attempts=8, max_timeout=128)
+                retry_client.retry_options.evaluate_response_callback = \
+                    NetworkUtility.should_retry_get_detail_image
                 async with retry_client.get(request_url) as response:
                     if response.status == 200:
                         data = await response.json()

--- a/utilities/network_utility.py
+++ b/utilities/network_utility.py
@@ -54,3 +54,18 @@ class NetworkUtility:
         if invalid_response:
             pass
         return invalid_response
+
+    @staticmethod
+    async def should_retry_get_detail_image(response: aiohttp.ClientResponse) -> bool:
+        """
+        Callback functions for the detail API for retrying.
+        :param response: The response to evaluate.
+        :return: Whether the request should be retried or not.
+        """
+        should_retry = True
+        if response.status == 200:
+            data = await response.json()
+            valid_response = data is not None and 'value' in data and data['value'] is not None
+            should_retry = not valid_response
+
+        return should_retry


### PR DESCRIPTION
This PR resolves #41.
An evaluation callback is added to retry requests that return a 200 if the data is not valid.
This PR combined with the timeout should prevent any issues with the detail API.
If not, the timeout and/or attempts may have to be increased by more.