### PR TITLE
fix: remove cookie_dict from Config class

### DIFF
--- a/utilities/config.py
+++ b/utilities/config.py
@@ -8,13 +8,11 @@ class Config:
     """
     _instance = None
     _config: dict = None
-    _cookie_dict: dict = None
 
     def __new__(cls, config: dict = None):
         if cls._instance is None:
             cls._instance = super(Config, cls).__new__(cls)
             cls._config = config
-            cls._cookie_dict = cls.get_cookie_dict()
         return cls._instance
 
     @property
@@ -59,36 +57,3 @@ class Config:
         :return: The value specified in the config file.
         """
         return self._config['detail_api']['max_attempts']
-
-    @staticmethod
-    def get_cookie_dict() -> dict:
-        """
-        Parses the cookie from the .env file into a dictionary.
-        :return: A dictionary containing the cookie values.
-        """
-        cookie = os.getenv('COOKIE')
-        cookie_values = cookie.split(';')
-        cookie_dict = {}
-        for cookie_value in cookie_values:
-            cookie_value = cookie_value.strip()
-            if '=' in cookie_value:
-                key, value = cookie_value.split('=', 1)
-                cookie_dict[key] = Config.__parse_cookie(value)
-        return cookie_dict
-
-    @staticmethod
-    def __parse_cookie(cookie_value: str) -> dict | str:
-        """
-        Recursively parse a cookie value into a dictionary.
-        :param cookie_value: The cookie value to parse.
-        :return: The parsed cookie value dictionary or string.
-        """
-        if '&' in cookie_value or '=' in cookie_value:
-            sub_dict = {}
-            for sub_value in cookie_value.split('&'):
-                if '=' in sub_value:
-                    sub_key, sub_value = sub_value.split('=', 1)
-                    sub_dict[sub_key] = Config.__parse_cookie(sub_value)
-            return sub_dict
-        else:
-            return cookie_value


### PR DESCRIPTION
This PR will resolve #46.  

The creation of the cookie_dict was experimental and not necessary after some testing. It was created when the Config instance was created, regardless of whether the .env file exists which lead to the described issue.
Because it is not used, this PR will completely remove it.